### PR TITLE
Fix header issue

### DIFF
--- a/src/PhoneId/PhoneId.php
+++ b/src/PhoneId/PhoneId.php
@@ -127,8 +127,7 @@ class PhoneId
 
         // Prepare headers
         if ($this->_accessToken) {
-            $headers = array('Authorization: Bearer ' . $this->_accessToken);
-            //$data['access_token'] = $this->_accessToken;
+            $headers[] = 'Authorization: Bearer ' . $this->_accessToken;
         }
 
         // Curl options

--- a/src/PhoneId/PhoneId.php
+++ b/src/PhoneId/PhoneId.php
@@ -127,8 +127,7 @@ class PhoneId
 
         // Prepare headers
         if ($this->_accessToken) {
-            // TODO $headers['Authorization'] = 'Bearer ' . $this->_accessToken;
-            $data['access_token'] = $this->_accessToken;
+            $headers[] = 'Authorization: Bearer ' . $this->_accessToken;
         }
 
         // Curl options

--- a/src/PhoneId/PhoneId.php
+++ b/src/PhoneId/PhoneId.php
@@ -127,8 +127,8 @@ class PhoneId
 
         // Prepare headers
         if ($this->_accessToken) {
-            // TODO $headers['Authorization'] = 'Bearer ' . $this->_accessToken;
-            $data['access_token'] = $this->_accessToken;
+            $headers = array('Authorization: Bearer ' . $this->_accessToken);
+            //$data['access_token'] = $this->_accessToken;
         }
 
         // Curl options


### PR DESCRIPTION
Penso che in questo modo si risolva il problema. Non sono un grande esperto di php, ma vedendo diversi esempio tutti creavano un array di headers in cui era scritto in maniera esplicita il valore dell'header voluto non come coppia chiave valore.
Non l'ho testato perché su questo mac non ho configurato nulla per fare il test
